### PR TITLE
fix indenting after commented `end`

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -315,6 +315,20 @@ a = 1"
    "# if foo
 a = 1"))
 
+(ert-deftest julia--test-indent-after-commented-end ()
+  "Ignore `end` in comments when indenting."
+  (julia--should-indent
+   "if foo
+a = 1
+#end
+b = 1
+end"
+   "if foo
+    a = 1
+    #end
+    b = 1
+end"))
+
 (ert-deftest julia--test-indent-import-export-using ()
   "Toplevel using, export, and import."
   (julia--should-indent

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -454,7 +454,8 @@ Do not move back beyond position MIN."
         (setq count
               (cond ((julia-at-keyword julia-block-start-keywords)
                      (+ count 1))
-                    ((equal (current-word t) "end")
+                    ((and (equal (current-word t) "end")
+                          (not (julia-in-comment)))
                      (- count 1))
                     (t count))))
       (if (> count 0)


### PR DESCRIPTION
this was broken for me by 0df9ca44c4ba888341801ea00bec6e83ab6b208b