### PR TITLE
font-locking for symbol at beginning of line

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -54,6 +54,16 @@
        (should (equal (buffer-substring-no-properties (point-min) (point-max))
                       ,to)))))
 
+(defmacro julia--should-font-lock (text pos face)
+  "Assert that TEXT at position POS gets font-locked with FACE in `julia-mode'."
+  `(with-temp-buffer
+     (julia-mode)
+     (insert ,text)
+     (if (fboundp 'font-lock-ensure)
+         (font-lock-ensure (point-min) (point-max))
+       (with-no-warnings
+         (font-lock-fontify-buffer)))
+     (should (eq ,face (get-text-property ,pos 'face)))))
 
 (ert-deftest julia--test-indent-if ()
   "We should indent inside if bodies."
@@ -349,6 +359,11 @@ using Foo: bar ,
     baz,
     quux
 notpartofit"))
+
+(ert-deftest julia--test-symbol-font-locking-at-bol ()
+  "Symbols get font-locked at beginning or line."
+  (julia--should-font-lock
+   ":a in keys(Dict(:a=>1))" 1 'julia-quoted-symbol-face))
 
 (defun julia--run-tests ()
   (interactive)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -291,7 +291,7 @@ This function provides equivalent functionality, but makes no efforts to optimis
 
 (defconst julia-quoted-symbol-regex
   ;; :foo and :foo2 are valid, but :123 is not.
-  (rx (or whitespace "(" "[" "," "=")
+  (rx (or bol whitespace "(" "[" "," "=")
       (group ":" (or letter (syntax symbol)) (0+ (or word (syntax symbol))))))
 
 (defconst julia-font-lock-keywords


### PR DESCRIPTION
hi, added `bol` to regex for symbol so 
`:a in ...` gets font-locked