### PR TITLE
completion-at-point for latexsubs

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -55,6 +55,16 @@
                       ,to)))))
 
 
+(defmacro julia--should-complete (from to)
+  "Assert that when the point is at the end of FROM, `completion-at-point'
+produces the text TO in `julia-mode'."
+  `(with-temp-buffer
+     (julia-mode)
+     (insert ,from)
+     (completion-at-point)
+     (should (equal (buffer-substring-no-properties (point-min) (point-max))
+                    ,to))))
+
 (ert-deftest julia--test-indent-if ()
   "We should indent inside if bodies."
   (julia--should-indent
@@ -349,6 +359,14 @@ using Foo: bar ,
     baz,
     quux
 notpartofit"))
+
+(ert-deftest julia--test-complete-latex ()
+  "We should complete after '\\'."
+  (julia--should-complete
+   "
+\\ster"
+   "
+\\sterling"))
 
 (defun julia--run-tests ()
   (interactive)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -646,6 +646,24 @@ meaning always increase indent on TAB and decrease on S-TAB."
     ;; ("Data" "^\\(.+\\)\\s-*<-[ \t\n]*\\(read\\|.*data\.frame\\).*(" 1)))
     ))
 
+;;; Completion
+
+;; Currently only completes latex symbols in `julia-latexsubs'
+(defun julia-completion-at-point-function ()
+  (let ((bnds (bounds-of-thing-at-point 'symbol)))
+    (when bnds
+      (cond
+       ;; complete latex symbol when current symbol is prefixed
+       ;; by '\'
+       ((eq (char-before (car bnds)) ?\\)
+        (list (1- (car bnds)) (cdr bnds) julia-latexsubs
+              :annotation-function
+              #'(lambda (arg)
+                  (gethash arg julia-latexsubs ""))))
+       ;; FIXME: other cases
+       ))))
+
+
 ;;;###autoload
 (define-derived-mode julia-mode julia-mode-prog-mode "Julia"
   "Major mode for editing julia code."
@@ -671,7 +689,10 @@ meaning always increase indent on TAB and decrease on S-TAB."
   (set (make-local-variable 'indent-line-function) 'julia-indent-line)
   (setq indent-tabs-mode nil)
   (setq imenu-generic-expression julia-imenu-generic-expression)
-  (imenu-add-to-menubar "Imenu"))
+  (imenu-add-to-menubar "Imenu")
+
+  ;; completion-at-point
+  (add-to-list 'completion-at-point-functions #'julia-completion-at-point-function))
 
 (defun julia-manual-deindent ()
   "Deindent by `julia-indent-offset' regardless of current


### PR DESCRIPTION
Adds a `julia-completion-at-point-function` for latexsubs

A simple completion at point function is added to 
`completion-at-point-functions` in `julia-mode`.  All it does currently is 
complete latex symbols from `julia-latexsubs` hash when the point is after
a symbol prefixed by '\'.

Also, adds a test for completing at point.
