### PR TITLE
Fix indentation for anonymous functions.

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -374,6 +374,27 @@ end"
     end
 end"))
 
+(ert-deftest julia--test-indent-keyword-paren ()
+  "indentation for ( following keywords"
+  "if( a>0 )
+end
+    
+    function( i=1:2 )
+        for( j=1:2 )
+            for( k=1:2 )
+            end
+            end
+        end"
+  "if( a>0 )
+end
+
+function( i=1:2 )
+    for( j=1:2 )
+        for( k=1:2 )
+        end
+    end
+end")
+
 (ert-deftest julia--test-symbol-font-locking-at-bol ()
   "Symbols get font-locked at beginning or line."
   (julia--should-font-lock

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -360,6 +360,20 @@ using Foo: bar ,
     quux
 notpartofit"))
 
+(ert-deftest julia--test-indent-anonymous-function ()
+  "indentation for function(args...)"
+  (julia--should-indent
+   "function f(x)
+function(y)
+x+y
+end
+end"
+   "function f(x)
+    function(y)
+        x+y
+    end
+end"))
+
 (ert-deftest julia--test-symbol-font-locking-at-bol ()
   "Symbols get font-locked at beginning or line."
   (julia--should-font-lock

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -405,6 +405,7 @@ a keyword if used as a field name, X.word, or quoted, :word."
   (and (or (= (point) 1)
 	   (and (not (equal (char-before (point)) ?.))
 		(not (equal (char-before (point)) ?:))))
+       (not (looking-at "("))           ; handle "function(" when on (
        (member (current-word t) kw-list)
        ;; 'end' is not a keyword when used for indexing, e.g. foo[end-2]
        (or (not (equal (current-word t) "end"))


### PR DESCRIPTION
This should fix issue #10. The problem was that when the indentation
algorithm traversed forms with `function(args...)`, and it was on the
`(`, `(julia-at-keyword julia-block-start-keywords)` would return `t`
because `(current-word t)` would return `function`.

The fix adds a check for this. Tests are also added.

Fix #10
