### PR TITLE
short function syntax: support return type declaration

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -425,7 +425,9 @@ end")
   (julia--should-font-lock
    "f(x) where T = 1" 1 'font-lock-function-name-face)
   (julia--should-font-lock
-   "f(x) where{T} = 1" 1 'font-lock-function-name-face))
+   "f(x) where{T} = 1" 1 'font-lock-function-name-face)
+  (dolist (def '("f(x)::T = 1" "f(x) :: T = 1" "f(x::X)::T where X = x"))
+    (julia--should-font-lock def 1 'font-lock-function-name-face)))
 
 (ert-deftest julia--test-where-keyword-font-locking ()
   (julia--should-font-lock

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -235,6 +235,8 @@ This function provides equivalent functionality, but makes no efforts to optimis
               (not (any "(" ")"))))
       ")"
       (* space)
+      (? "::" (* space) (1+ (not (any space))))
+      (* space)
       (* (seq "where" (or "{" (+ space)) (+ (not (any "=")))))
       "="
       (not (any "="))))


### PR DESCRIPTION
e.g. `f(x)::Int = x`