### PR TITLE
Insertion of math symbols in julia using auctex's mechanism

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -3194,6 +3194,28 @@ strings."
 (puthash "\\mtteight" "𝟾" julia-latexsubs)
 (puthash "\\mttnine" "𝟿" julia-latexsubs)
 
+;; Math insertion in julia. Use it with
+;; (add-hook 'julia-mode-hook 'julia-math-mode)
+;; (add-hook 'inferior-julia-mode-hook 'julia-math-mode)
+
+(when (require 'latex nil t)
+  (defun julia-math-insert (s)
+    "Inserts math symbol given by `s'"
+    (when s
+      (let ((sym (gethash (concat "\\" s) julia-latexsubs)))
+        (when sym
+          (insert sym)))))
+
+  (define-minor-mode julia-math-mode
+    "A minor mode with easy access to TeX math commands. The
+command is only entered if it is supported in Julia. The
+following commands are defined:
+
+\\{LaTeX-math-mode-map}"
+    nil nil (list (cons (LaTeX-math-abbrev-prefix) LaTeX-math-keymap))
+    (if julia-math-mode
+        (set (make-local-variable 'LaTeX-math-insert-function) 'julia-math-insert))))
+
 ;; Code for `inferior-julia-mode'
 (require 'comint)
 


### PR DESCRIPTION
This enables the insertion of mathematical symbols in Julia using the latex-math-mode mechanism of a prefix key. I'm not sure what the preferred mechanism is for an emacs package that depends on another one, here I just (require latex) and check for errors.