### PR TITLE
Fixed import export etc indentation at start of buffer.

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -342,20 +342,16 @@ end"))
 (ert-deftest julia--test-indent-import-export-using ()
   "Toplevel using, export, and import."
   (julia--should-indent
-   "
-export bar, baz,
+   "export bar, baz,
 quux"
-   "
-export bar, baz,
+   "export bar, baz,
     quux")
   (julia--should-indent
-   "
-using Foo: bar ,
+   "using Foo: bar ,
 baz,
 quux
 notpartofit"
-   "
-using Foo: bar ,
+   "using Foo: bar ,
     baz,
     quux
 notpartofit"))

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -437,7 +437,7 @@ symbol, gives up when this is not true."
         (module nil))                   ; found "Module:"
     (save-excursion
       (beginning-of-line)
-      (while (and (not done) (< 0 (point)))
+      (while (and (not done) (< (point-min) (point)))
         (julia-safe-backward-sexp)
         (cond
          ((looking-at (rx (or "import" "export" "using")))


### PR DESCRIPTION
Previously julia-mode would indent these keywords at the start of the
buffer, because the code had an error (point can never go below
point-min, which is at least 1). Fixed this, fixed tests (which
started with a blank line so did not catch this).