### PR TITLE
Allow user to set multiple arguments to inferior julia

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -3222,7 +3222,7 @@ strings."
   :type 'string
   :group 'julia)
 
-(defcustom julia-arguments '()
+(defcustom julia-arguments '("-i" "--color=yes")
   "Commandline arguments to pass to `julia-program'."
   :type '(repeat (string :tag "argument"))
   :group 'julia)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -3224,7 +3224,7 @@ strings."
 
 (defcustom julia-arguments '()
   "Commandline arguments to pass to `julia-program'."
-  :type 'string
+  :type '(repeat (string :tag "argument"))
   :group 'julia)
 
 (defvar julia-prompt-regexp "^\\w*> "
@@ -3244,7 +3244,8 @@ strings."
     (let ((julia-program julia-program)
           (buffer (get-buffer-create "*Julia*")))
       (when (not (comint-check-proc "*Julia*"))
-            (apply #'make-comint-in-buffer "Julia" "*Julia*" julia-program julia-arguments))
+        (apply #'make-comint-in-buffer "Julia" "*Julia*"
+               julia-program nil julia-arguments))
       (pop-to-buffer-same-window "*Julia*")
       (inferior-julia-mode)))
 


### PR DESCRIPTION
Also fix the call to make-comint-in-buffer so that it's passing the arguments to
julia rather than treating the first argument as the STARTFILE. This was a bug
with current implementation.

While I was in there, I added the `-i` and `--color=yes` flags to the default
flags. In almost all cases, the user will want those flags set.
