### PR TITLE
use cl-lib with emacs version >=24.3

### DIFF
--- a/julia-compat.el
+++ b/julia-compat.el
@@ -1,0 +1,68 @@
+;;; julia-compat.el --- Compatability with older emacses -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2009-2014 Julia contributors
+;; URL: https://github.com/JuliaLang/julia
+;; Version: 0.3
+;; Keywords: languages
+
+;;; License:
+;; Permission is hereby granted, free of charge, to any person obtaining
+;; a copy of this software and associated documentation files (the
+;; "Software"), to deal in the Software without restriction, including
+;; without limitation the rights to use, copy, modify, merge, publish,
+;; distribute, sublicense, and/or sell copies of the Software, and to
+;; permit persons to whom the Software is furnished to do so, subject to
+;; the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+;;; Usage:
+
+;;; Commentary:
+
+;; This is simple compatability for older emacses, eg. prior to addition of
+;; cl-lib in emacs 24.3
+
+;;; Code:
+
+;; We can't use cl-lib whilst supporting Emacs 23 users who don't use
+;; ELPA.
+(if (version< emacs-version "24.3")
+    (with-no-warnings
+      (require 'cl) ;; cl-incf, cl-decf, cl-plusp
+      (defmacro cl-incf (num) (incf num))
+      (defmacro cl-decf (num) (decf num))
+      (defmacro cl-plusp (num) (plusp num)))
+  (require 'cl-lib))
+
+;; define ignore-errors macro if it isn't present
+;; (necessary for emacs 22 compatibility)
+(when (not (fboundp 'ignore-errors))
+  (defmacro ignore-errors (body) `(condition-case nil ,body (error nil))))
+
+(defun julia--regexp-opt (strings &optional paren)
+  "Emacs 23 provides `regexp-opt', but it does not support PAREN taking the \
+value 'symbols.
+This function provides equivalent functionality, but makes no efforts to \
+optimise the regexp."
+  (cond
+   ((>= emacs-major-version 24)
+    (regexp-opt strings paren))
+   ((not (eq paren 'symbols))
+    (regexp-opt strings paren))
+   ((null strings)
+    "")
+   ('t
+    (rx-to-string `(seq symbol-start (or ,@strings) symbol-end)))))
+
+(provide 'julia-compat)
+;;; julia-compat.el ends here

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -36,11 +36,6 @@
 
 ;;; Code:
 
-;; We can't use cl-lib whilst supporting Emacs 23 users who don't use
-;; ELPA.
-(with-no-warnings
-  (require 'cl)) ;; incf, decf, plusp
-
 (require 'julia-mode)
 (require 'ert)
 

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -34,11 +34,7 @@
 ;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; Code:
-
-;; We can't use cl-lib whilst supporting Emacs 23 users who don't use
-;; ELPA.
-(with-no-warnings
-  (require 'cl)) ;; incf, decf, plusp
+(require 'julia-compat)
 
 (defvar julia-mode-hook nil)
 
@@ -65,24 +61,6 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jl\\'" . julia-mode))
-
-;; define ignore-errors macro if it isn't present
-;; (necessary for emacs 22 compatibility)
-(when (not (fboundp 'ignore-errors))
-  (defmacro ignore-errors (body) `(condition-case nil ,body (error nil))))
-
-(defun julia--regexp-opt (strings &optional paren)
-  "Emacs 23 provides `regexp-opt', but it does not support PAREN taking the value 'symbols.
-This function provides equivalent functionality, but makes no efforts to optimise the regexp."
-  (cond
-   ((>= emacs-major-version 24)
-    (regexp-opt strings paren))
-   ((not (eq paren 'symbols))
-    (regexp-opt strings paren))
-   ((null strings)
-    "")
-   ('t
-    (rx-to-string `(seq symbol-start (or ,@strings) symbol-end)))))
 
 (defvar julia-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -397,14 +375,14 @@ As a result, it is true inside \"foo\", `foo` and 'f'."
         (unless (or (julia-in-string) (julia-in-comment))
 
           (when (looking-at (rx "["))
-            (incf open-count))
+            (cl-incf open-count))
           (when (looking-at (rx "]"))
-            (decf open-count)))
+            (cl-decf open-count)))
 
         (forward-char 1)))
 
     ;; If we've opened more than we've closed, we're inside brackets.
-    (plusp open-count)))
+    (cl-plusp open-count)))
 
 (defun julia-at-keyword (kw-list)
   "Return the word at point if it matches any keyword in KW-LIST.
@@ -543,7 +521,7 @@ the (possibly narrowed) buffer, so there is nowhere else to go."
          ((and (= 0 this-move)
                (or (looking-at-p "^\\s-*\\(?:#.*\\)*$")
                    (julia-in-comment)))
-          (incf moved))
+          (cl-incf moved))
          ;; success
          ((= 0 this-move)
           (throw 'result (1+ moved)))


### PR DESCRIPTION
use cl-lib when emacs major version is >23. Just adds some
compatability macros, `cl-plusp` is a `defsubst`