### PR TITLE
Make julia-latexsub work if point in the middle of latex symbol.

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -819,18 +819,20 @@ strings."
 
 (defun julia-latexsub ()
   "Perform a LaTeX-like Unicode symbol substitution."
-  (interactive "*i")
-  (let ((orig-pt (point)))
+  (interactive "*")
+  (let ((orig-pt (point))
+        (word-end (progn (forward-word)
+                         (point))))
     (while (not (or (bobp) (= ?\\ (char-before))
 		    (= ?\s (char-syntax (char-before)))))
       (backward-char))
     (if (and (not (bobp)) (= ?\\ (char-before)))
         (progn
           (backward-char)
-          (let ((sub (gethash (buffer-substring (point) orig-pt) julia-latexsubs)))
+          (let ((sub (gethash (buffer-substring (point) word-end) julia-latexsubs)))
             (if sub
                 (progn
-                  (delete-region (point) orig-pt)
+                  (delete-region (point) word-end)
                   (insert sub))
               (goto-char orig-pt))))
       (goto-char orig-pt))))


### PR DESCRIPTION
This pull request fixes two minor issues I had:

1. emacs was erroring off because the `invoke-command` machinery was calling the zero-argument function `julia-latexsub` with a nil argument.  Removing the `i` in the argument specifier string fixed this (might be a Spacemacs issue, not a julia-mode issue).
2. It wasn't doing the substitution if point is in the middle of the latex command string.

The second change seems relatively innocuous, the first might break things that invoke `julia-latexsub` in ways that Spacemacs doesn't, i.e. with an argument (although it hasn't broken anything for me)