### PR TITLE
wrap load with check against load-file-name

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -853,7 +853,8 @@ strings."
 
 ;;; populate LaTeX symbols hash table from a generated file.
 ;;; (See Julia issue #8947 for why we don't use the Emacs tex input mode.)
-(load (expand-file-name "julia-latexsubs" (file-name-directory load-file-name)))
+(load (expand-file-name "julia-latexsubs"
+                        (file-name-directory (or buffer-file-name load-file-name))))
 
 ;; Math insertion in julia. Use it with
 ;; (add-hook 'julia-mode-hook 'julia-math-mode)


### PR DESCRIPTION
Simply wraps call to `load` so `eval-buffer` doesn't error