### PR TITLE
RFC: Make inferior-julia smarter

### DIFF
--- a/inferior-julia.el
+++ b/inferior-julia.el
@@ -1,0 +1,151 @@
+;;; inferior-julia.el --- Major mode for interacting with an inferior Julia process -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020 julia-mode contributors
+
+;;; Commentary:
+;;
+;; `inferior-julia-mode' provides a Julia REPL from within emacs. To
+;; use it, execute M-x `run-julia'.
+
+;;; Code:
+
+(require 'julia-mode)
+(require 'comint)
+
+(defgroup inferior-julia ()
+  "Major mode for interacting with an inferior Julia process."
+  :group 'julia
+  :prefix "inferior-julia-")
+
+(defcustom inferior-julia-program "julia"
+  "Path to the program used by `inferior-julia'."
+  :type 'string)
+
+(defcustom inferior-julia-buffer "*Inferior Julia*"
+  "Name of buffer for running an inferior Julia process."
+  :type 'string)
+
+(defcustom inferior-julia-arguments '("-i" "--color=yes" "-q")
+  "Commandline arguments to pass to `inferior-julia-program'."
+  :type '(repeat (string :tag "argument")))
+
+(defcustom inferior-julia-prompt-read-only comint-prompt-read-only
+  "If non-nil, the Julia prompt is read only."
+  :type 'boolean)
+
+;; We need to know where this location is in order to correctly
+;; support visiting source of stacktrace in compilation-mode
+(defvar inferior-julia-depot
+  (with-output-to-string
+    (call-process inferior-julia-program nil standard-output nil
+                  "--startup-file=no" "-e" "print(last(DEPOT_PATH))"))
+  "Path to directory containing Julia base and stdlib.")
+
+(defvar inferior-julia--depot-base-format
+  (concat
+   (file-name-as-directory (expand-file-name "base" inferior-julia-depot))
+   "%s")
+  "Format string to use with stacktraces with Julia Base paths.")
+
+(defvar inferior-julia-prompt-regexp "^\\w*> "
+  "Regexp for matching `inferior-julia' prompt.")
+
+(defvar inferior-julia-error-regexp-alist
+  (list
+   ;; TODO: see https://github.com/JuliaLang/julia/issues/35191 for
+   ;; reason why this doesn't work yet for stdlib.
+   (list (rx line-start " [" (1+ num) "] " (1+ nonl)
+             " at " (group-n 3
+                             (group-n 1 ?/ (1+ (not (any ?\n ?:))))
+                             ?:
+                             (group-n 2 (1+ num))))
+         1 2 nil nil 3)
+   ;; The FILE for stack frames from Base looks like "./array.jl"
+   (list (rx line-start " [" (1+ num) "] " (1+ nonl)
+             " at " (group-n 3
+                             ?. (any ?\\ ?/) (group-n 1 (1+ (not (any ?\n ?:))))
+                             ?:
+                             (group-n 2 (1+ num))))
+         (list 1 inferior-julia--depot-base-format) 2 nil nil 3)
+   (list (rx line-start " [" (1+ num) "] " (1+ nonl) " at " (group "none:1"))
+         nil nil nil nil 1))
+  "Value for `compilation-error-regexp-alist' in inferior Julia.")
+
+(defvar inferior-julia-mode-map
+  (nconc (make-sparse-keymap) comint-mode-map)
+  "Basic mode map for `inferior-julia-mode'.")
+
+(defvar inferior-julia-mode-syntax-table
+  (make-syntax-table julia-mode-syntax-table)
+  "Syntax table for use in `inferior-julia-mode' buffers.")
+
+(defun inferior-julia--send (proc string)
+  "Send STRING to inferior Julia PROC.
+Checks if first character in STRING is special. \"?\" invokes Julia
+help, \"]\" uses the Pkg repl, and \";\" sends shell commands."
+  (let* ((c (aref string 0))
+         (wrapped-string (substring string 1))
+         (wrapper (cond
+                   ((char-equal c ??)
+                    "eval(_InferiorJulia.REPL.helpmode(\"%s\"))")
+                   ((char-equal c ?\])
+                    "_InferiorJulia.Pkg.pkg\"%s\"")
+                   ((char-equal c ?\;)
+                    "Base.repl_cmd(`%s`, stdout)")
+                   (t
+                    (setq wrapped-string string)
+                    "%s"))))
+    (comint-simple-send proc (format wrapper wrapped-string))))
+
+;;;###autoload
+(defun inferior-julia (&optional arg)
+    "Run an inferior instance of julia inside Emacs."
+    (interactive "P")
+    (let ((buffer (get-buffer-create inferior-julia-buffer)))
+      (unless arg
+        (pop-to-buffer buffer))
+      (with-current-buffer buffer
+        (let ((proc (apply #'make-comint
+                           (substring inferior-julia-buffer 1 -1)
+                           inferior-julia-program nil
+                           inferior-julia-arguments)))
+          ;; Pkg and REPL modules must be accessible for ] and ? magics
+          (comint-send-string
+           proc "baremodule _InferiorJulia import Pkg, REPL end;\n"))
+        (inferior-julia-mode))
+      buffer))
+
+(define-derived-mode inferior-julia-mode comint-mode "Inferior Julia"
+  "Major mode for interacting with an inferior Julia process.
+
+Key bindings:
+\\<inferior-julia-mode-map>"
+  :group 'inferior-julia
+  (set-syntax-table inferior-julia-mode-syntax-table)
+  (setq-local comment-use-syntax t)
+  (setq-local comment-start "# ")
+  (setq-local comment-start-skip "#+\\s-*")
+  (setq-local font-lock-defaults '(julia-font-lock-keywords t))
+  (setq-local syntax-propertize-function julia-syntax-propertize-function)
+  (setq-local indent-line-function #'julia-indent-line)
+  (setq-local beginning-of-defun-function #'julia-beginning-of-defun)
+  (setq-local end-of-defun-function #'julia-end-of-defun)
+  (setq-local indent-tabs-mode nil)
+
+  (setq-local comint-prompt-regexp inferior-julia-prompt-regexp)
+  (setq-local comint-prompt-read-only inferior-julia-prompt-read-only)
+
+  (setq-local compilation-error-regexp-alist inferior-julia-error-regexp-alist)
+  (compilation-shell-minor-mode 1)
+  (compilation-forget-errors)
+
+  (setq-local paragraph-start inferior-julia-prompt-regexp)
+
+  (setq-local comint-input-sender #'inferior-julia--send))
+
+;;;###autoload
+(defalias 'run-julia #'inferior-julia
+  "Run an inferior instance of julia inside Emacs.")
+
+(provide 'inferior-julia)
+;;; inferior-julia.el ends here

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -749,6 +749,7 @@ Return nil if point is not in a function, otherwise point."
 (define-derived-mode julia-mode prog-mode "Julia"
   "Major mode for editing julia code."
   (set-syntax-table julia-mode-syntax-table)
+  (setq-local comment-use-syntax t)
   (setq-local comment-start "# ")
   (setq-local comment-start-skip "#+\\s-*")
   (setq-local font-lock-defaults '(julia-font-lock-keywords))
@@ -818,61 +819,6 @@ following commands are defined:
       nil nil (list (cons (LaTeX-math-abbrev-prefix) LaTeX-math-keymap))
       (if julia-math-mode
           (setq-local LaTeX-math-insert-function #'julia-math-insert)))))
-
-;; Code for `inferior-julia-mode'
-(require 'comint)
-
-(defcustom julia-program "julia"
-  "Path to the program used by `inferior-julia'."
-  :type 'string
-  :group 'julia)
-
-(defcustom julia-arguments '("-i" "--color=yes")
-  "Commandline arguments to pass to `julia-program'."
-  :type '(repeat (string :tag "argument"))
-  :group 'julia)
-
-(defvar julia-prompt-regexp "^\\w*> "
-  "Regexp for matching `inferior-julia' prompt.")
-
-(defvar inferior-julia-mode-map
-  (let ((map2 (nconc (make-sparse-keymap) comint-mode-map)))
-    ;; example definition
-    (define-key map2 (kbd "TAB") 'julia-latexsub-or-indent)
-    map2)
-  "Basic mode map for `inferior-julia-mode'.")
-
-;;;###autoload
-(defun inferior-julia ()
-    "Run an inferior instance of julia inside Emacs."
-    (interactive)
-    (let ((julia-program julia-program))
-      (when (not (comint-check-proc "*Julia*"))
-        (apply #'make-comint-in-buffer "Julia" "*Julia*"
-               julia-program nil julia-arguments))
-      (pop-to-buffer-same-window "*Julia*")
-      (inferior-julia-mode)))
-
-(defun inferior-julia--initialize ()
-    "Helper function to initialize `inferior-julia'."
-    (setq comint-use-prompt-regexp t))
-
-(define-derived-mode inferior-julia-mode comint-mode "Julia"
-  "Major mode for `inferior-julia'.
-
-\\<inferior-julia-mode-map>"
-  nil "Julia"
-  (setq-local comint-prompt-regexp julia-prompt-regexp)
-  (setq-local comint-prompt-read-only t)
-  (setq-local font-lock-defaults '(julia-font-lock-keywords t))
-  (setq-local paragraph-start julia-prompt-regexp)
-  (setq-local indent-line-function #'julia-indent-line))
-
-(add-hook 'inferior-julia-mode-hook #'inferior-julia--initialize)
-
-;;;###autoload
-(defalias 'run-julia #'inferior-julia
-  "Run an inferior instance of julia inside Emacs.")
 
 (provide 'julia-mode)
 


### PR DESCRIPTION
This is not at a point where's it's ready to merge yet.

Basically, I'd like feedback before I put more time into this on whether other people find this useful. Instead of having people using any one of [emacs-jupyter](https://github.com/dzop/emacs-jupyter), [ess](https://github.com/emacs-ess/ESS), or [julia-repl](https://github.com/tpapp/julia-repl) to get a Julia REPL in Emacs, why not just improve the one we already have?

Much of the work in this PR takes its inspiration from the builtin `inferior-octave`.

This PR implements:

- `?`, `]`, and `;` REPL modes (I wouldn't be against adding piecemeal support for things like the debugger or perhaps just creating an entirely separate comint-based mode for that).
- Navigate to the file/line shown in error stacktraces by clicking or hovering point and pressing enter.
- Rudimentary completion (see caveats in the second commit).

Future work:

- Use completion from `inferior-julia` in `julia-mode`.
- Allow multiple instances of `inferior-julia`.
- `eldoc-documentation-function` integration.
- etc.

I'm submitting this here not because I think it's ready to be merged (the issues in the completion commit need fixed first) but to get feedback on whether others would find value in me putting more time into this or whether everyone finds the existing situation with in-emacs Julia REPLs tolerable. Please try this PR and give any feedback. I'd hate to add a bunch of code that simply sits and rots if I ever lose use for it for whatever reason...

Thoughts? Do we want a full-featured REPL included in `julia-mode` or is this better relegated to external packages?