### PR TITLE
Add integration with project.el

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
 script:
   - $EMACS --version
-  - $EMACS --batch -L . --eval "(and (>= emacs-major-version 24) (setq byte-compile-error-on-warn t))" -f batch-byte-compile julia-mode.el
+  - $EMACS --batch -L . --eval "(progn (and (>= emacs-major-version 24) (setq byte-compile-error-on-warn t)) (package-initialize) (package-install-file \"julia-mode.el\"))" -f batch-byte-compile julia-mode.el
   - $EMACS -batch -L . -l ert -l julia-mode-tests.el -f ert-run-tests-batch-and-exit;
 
 notifications:

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -4,7 +4,7 @@
 ;; URL: https://github.com/JuliaEditorSupport/julia-emacs
 ;; Version: 0.4
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.3") (cl-generic "0.3"))
 
 ;;; Usage:
 ;; Put the following code in your .emacs, site-load.el, or other relevant file
@@ -37,6 +37,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'cl-generic)
 (require 'julia-mode-latexsubs)
 (require 'project nil t)
 


### PR DESCRIPTION
This code is already used by eglot-jl to locate Julia projects and
will be useful in the future for other Julia packages (such as for
REPLs to decide which files they're associated with). Putting it in
the julia-mode package means it doesn't have to be redefined each time
it's used.