### PR TITLE
Give \ punctuation syntax outside of strings

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -262,7 +262,14 @@ qux"
 foo() |>
     bar |>
     baz
-qux"))
+qux")
+  (julia--should-indent
+   "x \\
+y \\
+z"
+   "x \\
+    y \\
+    z"))
 
 (ert-deftest julia--test-indent-ignores-blank-lines ()
   "Blank lines should not affect indentation of non-blank lines."
@@ -396,13 +403,13 @@ end"))
 (ert-deftest julia--test-backslash-indent ()
   "indentation for function(args...)"
   (julia--should-indent
-   "(\)
+   "(\\)
    1
-   (:\)
+   (:\\)
        1"
-   "(\)
+   "(\\)
 1
-(:\)
+(:\\)
 1"))
 
 (ert-deftest julia--test-indent-keyword-paren ()

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -665,6 +665,32 @@ end" 'end-of-defun "n == 0" "return fact(x)[ \n]+end" 'end 2))
   ; (should (equal (julia--substitute "\\alpha" 6) "α")) ; BROKEN
   )
 
+;;; syntax-propertize-function tests
+
+(ert-deftest julia--test-triple-quoted-string-syntax ()
+  (with-temp-buffer
+    (julia-mode)
+    (insert "\"\"\"
+hello world
+\"\"\"")
+    ;; If triple-quoted strings improperly syntax-propertized as 3
+    ;; single-quoted strings, this will show string starting at pos 3
+    ;; instead of 1.
+    (should (= 1 (nth 8 (syntax-ppss 5))))))
+
+(ert-deftest julia--test-backslash-syntax ()
+  (with-temp-buffer
+    (julia-mode)
+    (insert "1 \\ 2
+\"hello\\nthere\"")
+    (syntax-propertize 20)
+    (should (equal
+             (string-to-syntax ".")
+             (syntax-after 3)))
+    (should (equal
+             (string-to-syntax "\\")
+             (syntax-after 13)))))
+
 ;;;
 ;;; run all tests
 ;;;

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -180,18 +180,6 @@
              "::" "."))
           (regexp-opt '(" #" " \n" "#" "\n"))))
 
-(defconst julia-triple-quoted-string-regex
-  ;; We deliberately put a group on the first and last delimiter, so
-  ;; we can mark these as string delimiters for font-lock.
-  (rx (group "\"")
-      (group "\"\""
-             ;; After the delimiter, we're a sequence of
-             ;; non-backslashes or blackslashes paired with something.
-             (*? (or (not (any "\\"))
-                     (seq "\\" anything)))
-             "\"\"")
-      (group "\"")))
-
 (defconst julia-unquote-regex
   "\\(\\s(\\|\\s-\\|-\\|[,%=<>\\+*/?&|!\\^~\\\\;:]\\|^\\)\\($[a-zA-Z0-9_]+\\)")
 
@@ -313,33 +301,21 @@
 (defconst julia-block-end-keywords
   (list "end" "else" "elseif" "catch" "finally"))
 
-(defun julia-stringify-triple-quote ()
-  "Put `syntax-table' property on triple-quoted string delimiters.
-
-Based on `python-syntax-stringify'."
-  (let* ((string-start-pos (- (point) 3))
-         (string-end-pos (point))
-         (ppss (prog2
-                   (backward-char 3)
-                   (syntax-ppss)
-                 (forward-char 3)))
-         (in-comment (nth 4 ppss))
-         (in-string (nth 8 ppss)))
-    (unless in-comment
-      (if in-string
-          ;; We're in a string, so this must be the closing triple-quote.
-          ;; Put | on the last " character.
-          (put-text-property (1- string-end-pos) string-end-pos
-                             'syntax-table (string-to-syntax "|"))
-        ;; We're not in a string, so this is the opening triple-quote.
-        ;; Put | on the first " character.
-        (put-text-property string-start-pos (1+ string-start-pos)
-                           'syntax-table (string-to-syntax "|"))))))
-
 (defconst julia-syntax-propertize-function
   (syntax-propertize-rules
-   ("\"\"\""
-    (0 (ignore (julia-stringify-triple-quote))))
+   ;; triple-quoted strings are a single string rather than 3
+   ((rx (group ?\") ?\" (group ?\"))
+    (1 (let ((ppss (save-excursion (syntax-ppss (match-beginning 0)))))
+         (unless (or (nth 3 ppss) (nth 4 ppss))
+           (string-to-syntax "|"))))
+    (2 (let ((ppss (save-excursion (syntax-ppss (match-beginning 0)))))
+         (unless (nth 4 ppss)
+           (when (nth 3 ppss)
+             (string-to-syntax "|"))))))
+   ;; backslash acts as an operator if it's not inside a string
+   ("\\\\"
+    (0 (unless (nth 3 (save-excursion (syntax-ppss (match-beginning 0))))
+         (string-to-syntax "."))))
    (julia-char-regex
     (1 "\"")                    ; Treat ' as a string delimiter.
     (2 ".")                     ; Don't highlight anything between.


### PR DESCRIPTION
Fixes #58
Fixes #59

This commit also fixes a broken test for backslash indentation by
properly escaping backslashes in elisp strings and cleans up the code
for syntax-propertizing triple-quoted strings as a single string
rather than 3 strings.