### PR TITLE
Recognize whole triple-quoted string with regex instead of partial

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -513,6 +513,17 @@ end")
     (julia--should-font-lock string 74 font-lock-type-face) ; B
     ))
 
+(ert-deftest julia--test-triple-quote-string-font-lock ()
+  "Test that triple quoted strings are font-locked correctly even with escapes."
+  (let ((s1 "\"\"\"a\\\"\\\"\"b\"\"\"d")
+        (s2 "\"\"\"a\\\"\"\"b\"\"\"d"))
+    (julia--should-font-lock s1 4 font-lock-string-face)
+    (julia--should-font-lock s1 10 font-lock-string-face)
+    (julia--should-font-lock s1 14 nil)
+    (julia--should-font-lock s2 4 font-lock-string-face)
+    (julia--should-font-lock s2 9 font-lock-string-face)
+    (julia--should-font-lock s2 13 nil)))
+
 ;;; Movement
 (ert-deftest julia--test-beginning-of-defun-assn-1 ()
   "Point moves to beginning of single-line assignment function."

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -304,14 +304,17 @@
 (defconst julia-syntax-propertize-function
   (syntax-propertize-rules
    ;; triple-quoted strings are a single string rather than 3
-   ((rx (group ?\") ?\" (group ?\"))
+   ((rx (group ?\") "\"\""
+        (*? (or (not (any ?\\)) (and ?\\ anything)))
+        "\"\"" (group ?\"))
     ;; First " starts a string if not already inside a string (or comment)
-    (1 (let ((ppss (save-excursion (syntax-ppss (match-beginning 0)))))
-         (unless (or (nth 3 ppss) (nth 4 ppss))
-           (string-to-syntax "|"))))
+    (1 (unless (julia-syntax-comment-or-string-p
+                (save-excursion (syntax-ppss (match-beginning 0))))
+         (string-to-syntax "|")))
     ;; Last " ends a string if already inside a string
-    (2 (and (nth 3 (save-excursion (syntax-ppss (match-beginning 0))))
-            (string-to-syntax "|"))))
+    (2 (unless (julia-syntax-comment-or-string-p
+                (save-excursion (syntax-ppss (match-beginning 0))))
+         (string-to-syntax "|"))))
    ;; backslash acts as an operator if it's not inside a string
    ("\\\\"
     (0 (unless (nth 3 (save-excursion (syntax-ppss (match-beginning 0))))

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -297,6 +297,21 @@
 (defconst julia-block-end-keywords
   (list "end" "else" "elseif" "catch" "finally"))
 
+(defsubst julia-syntax-comment-or-string-p (&optional syntax-ppss)
+  "Return non-nil if SYNTAX-PPSS is inside string or comment."
+  (nth 8 (or syntax-ppss (syntax-ppss))))
+
+(defun julia-in-comment (&optional syntax-ppss)
+  "Return non-nil if point is inside a comment using SYNTAX-PPSS.
+Handles both single-line and multi-line comments."
+  (nth 4 (or syntax-ppss (syntax-ppss))))
+
+(defun julia-in-string (&optional syntax-ppss)
+  "Return non-nil if point is inside a string using SYNTAX-PPSS.
+Note this is Emacs' notion of what is highlighted as a string.
+As a result, it is true inside \"foo\", `foo` and 'f'."
+  (nth 3 (or syntax-ppss (syntax-ppss))))
+
 (defconst julia-syntax-propertize-function
   (syntax-propertize-rules
    ;; triple-quoted strings are a single string rather than 3
@@ -320,17 +335,6 @@
     (1 "\"")                    ; Treat ' as a string delimiter.
     (2 ".")                     ; Don't highlight anything between.
     (3 "\"")))) ; Treat the last " in """ as a string delimiter.
-
-(defun julia-in-comment (&optional syntax-ppss)
-  "Return non-nil if point is inside a comment using SYNTAX-PPSS.
-Handles both single-line and multi-line comments."
-  (nth 4 (or syntax-ppss (syntax-ppss))))
-
-(defun julia-in-string (&optional syntax-ppss)
-  "Return non-nil if point is inside a string using SYNTAX-PPSS.
-Note this is Emacs' notion of what is highlighted as a string.
-As a result, it is true inside \"foo\", `foo` and 'f'."
-  (nth 3 (or syntax-ppss (syntax-ppss))))
 
 (defun julia-in-brackets ()
   "Return non-nil if point is inside square brackets."
@@ -590,10 +594,6 @@ TYPE can be `comment', `string' or `paren'."
     (cond
      ((nth 8 ppss) (if (nth 4 ppss) 'comment 'string))
      ((nth 1 ppss) 'paren))))
-
-(defsubst julia-syntax-comment-or-string-p (&optional syntax-ppss)
-  "Return non-nil if SYNTAX-PPSS is inside string or comment."
-  (nth 8 (or syntax-ppss (syntax-ppss))))
 
 (defun julia-looking-at-beginning-of-defun (&optional syntax-ppss)
   "Check if point is at `beginning-of-defun' using SYNTAX-PPSS."

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -322,7 +322,7 @@ As a result, it is true inside \"foo\", `foo` and 'f'."
     (1 (unless (julia-syntax-comment-or-string-p
                 (save-excursion (syntax-ppss (match-beginning 0))))
          (string-to-syntax "|")))
-    ;; Last " ends a string if already inside a string
+    ;; Last " ends a string unless first " did not start string
     (2 (unless (julia-syntax-comment-or-string-p
                 (save-excursion (syntax-ppss (match-beginning 0))))
          (string-to-syntax "|"))))


### PR DESCRIPTION
Fixes #15

Feels kind of silly to make such a small change after just working on
this, but #113 made this fix much more obvious.