### PR TITLE
Correct the conditional for detecting if auctex is loaded

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -774,7 +774,7 @@ strings."
 ;; (add-hook 'julia-mode-hook 'julia-math-mode)
 ;; (add-hook 'inferior-julia-mode-hook 'julia-math-mode)
 
-(when (require 'latex nil t)
+(when (featurep 'latex)
   (declare-function LaTeX-math-abbrev-prefix "latex")
 
   (defun julia-math-insert (s)


### PR DESCRIPTION
The `require` statement caused `auctex` to be loaded and then break `prettify-symbols-mode`. The `featurep` appears to be the correct way to check. Seems to pass the tests when I ran them. 