### PR TITLE
Minor point about preferring the rx macro for regexs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ Please
 
 2. add a short summary in the [Unreleased section of the CHANGELOG](CHANGELOG.md#unreleased).
 
+3. use the `rx` macro (S-expressions) whenever rewriting existing regular expressions or introducing new ones; it keeps the code much more readable.
+
 We do our best to provide feedback within 2 weeks, feel free to bump in a comment after that.


### PR DESCRIPTION
For any code that is updated, I think we should prefer `rx` to string regexp.

Rewrites to existing code are welcome.