### PR TITLE
Do not consider `:end` as block ending

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -441,7 +441,16 @@ r = 1
 end"
    "if a == :end
     r = 1
-end"))
+end")
+
+  (julia--should-indent
+   "if a == a[end-4:end]
+r = 1
+end"
+   "if a == a[end-4:end]
+    r = 1
+end")
+  )
 
 (ert-deftest julia--test-symbol-font-locking-at-bol ()
   "Symbols get font-locked at beginning or line."

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -433,6 +433,16 @@ function( i=1:2 )
     end
 end")
 
+(ert-deftest julia--test-indent-ignore-:end-as-block-ending ()
+  "Do not consider `:end` as a block ending."
+  (julia--should-indent
+   "if a == :end
+r = 1
+end"
+   "if a == :end
+    r = 1
+end"))
+
 (ert-deftest julia--test-symbol-font-locking-at-bol ()
   "Symbols get font-locked at beginning or line."
   (julia--should-font-lock

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -411,10 +411,7 @@ Do not move back beyond position MIN."
         (setq nesting-count
               (cond ((julia-at-keyword julia-block-start-keywords)
                      (+ nesting-count 1))
-                    ((and (equal (current-word t) "end")
-                          (not (julia-in-comment))
-                          ;; Do not consider the symbol `:end` a block ending.
-                          (not (equal (char-before (point)) ?:)))
+                    ((julia-at-keyword '("end"))
                      (- nesting-count 1))
                     (t nesting-count))))
       (if (> nesting-count 0)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -412,7 +412,9 @@ Do not move back beyond position MIN."
               (cond ((julia-at-keyword julia-block-start-keywords)
                      (+ nesting-count 1))
                     ((and (equal (current-word t) "end")
-                          (not (julia-in-comment)))
+                          (not (julia-in-comment))
+                          ;; Do not consider the symbol `:end` a block ending.
+                          (not (equal (char-before (point)) ?:)))
                      (- nesting-count 1))
                     (t nesting-count))))
       (if (> nesting-count 0)


### PR DESCRIPTION
The word `:end` was being considered as a block ending. Hence, the
following code:

```julia
if a == :end
    r = 1
end
```

was being incorrectly indented:

```
if a == :end
r = 1
end
```