### PR TITLE
imenu fixes

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -700,15 +700,69 @@ Return nil if point is not in a function, otherwise point."
       (end-of-line)
       (point))))
 
+(defconst julia-imenu-private-multiline-fn
+  (rx-to-string
+   '(seq bol
+         (zero-or-more space)
+         (zero-or-one "@" (one-or-more alnum) space)
+         "function"
+         (one-or-more space)
+         (group "_" (minimal-match (zero-or-more anything)))
+         (or (seq (one-or-more space) "end") eol))))
+
+(defconst julia-imenu-public-multiline-fn
+  (rx-to-string
+   '(seq bol
+         (zero-or-more space)
+         (zero-or-one "@" (one-or-more alnum) space)
+         "function"
+         (one-or-more space)
+         (group (not (any "_")) (zero-or-more not-newline)))))
+
+(defconst julia-imenu-private-singleline-fn
+  (rx-to-string
+   '(seq bol
+         (zero-or-more space)
+         (zero-or-one "@" (one-or-more alnum) space)
+         (group "_"
+                (one-or-more (any "!" "." "_" alnum))
+                "(" (minimal-match (zero-or-more not-newline)) ")")
+         (minimal-match (zero-or-more not-newline)) space "=" space)))
+
+(defconst julia-imenu-public-singleline-fn
+  (rx-to-string
+   '(seq line-start
+         (zero-or-more space)
+         (zero-or-one "@" (one-or-more alnum) space)
+         (group (any "!" "." alnum)
+                (zero-or-more (any "!" "." "_" alnum))
+                "(" (minimal-match (zero-or-more not-newline)) ")")
+         (minimal-match (zero-or-more not-newline)) space "=" space)))
+
+(defconst julia-imenu-const
+  (rx-to-string
+   '(seq bol
+         (zero-or-more space)
+         "const"
+         space
+         (group (one-or-more alnum))
+         (zero-or-more space) "=" space)))
+
+(defconst julia-imenu-struct
+  (rx-to-string
+   '(seq bol
+         (zero-or-more space)
+         (group (zero-or-one "mutable" space) "struct" space (one-or-more alnum)))))
+
 ;;; IMENU
-(defvar julia-imenu-generic-expression
+(setq julia-imenu-generic-expression
   ;; don't use syntax classes, screws egrep
-  '(("Function (_)" "^[ \t]*\\(@.+ \\)?function[ \t]+\\(_.*?\\)\\( +end\\|$\\)" 2)
-    ("Function (_)" "^[ \t]*\\(@.+ \\)?\\(_[!\._a-zA-Z0-9]+\(.*\).*\\) = " 2)
-    ("Function" "^[ \t]*\\(@.+ \\)?function[ \t]+\\([^_].*?\\)\\( +end\\|$\\)" 2)
-    ("Function" "^[ \t]*\\(@.+ \\)?\\([!\.a-zA-Z0-9][!\._a-zA-Z0-9]*\(.*\).*\\) = " 2)
-    ("Const" "^[ \t]*const \\([^ \t\n]*\\) *= " 1)
-    ("Struct" "^[ \t]*\\(\\(mutable \\)*struct [^ \t\n]*\\)" 1)
+  `(("Function" ,julia-imenu-public-multiline-fn 1)
+    ("Function" ,julia-imenu-public-singleline-fn 1)
+    ("Function (_)" ,julia-imenu-private-multiline-fn 1)
+    ("Function (_)" ,julia-imenu-private-singleline-fn 1)
+    ("Const" ,julia-imenu-const 1)
+    ("Struct" ,julia-imenu-struct 1)
     ("Require" " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)
     ("Include" " *\\(\\binclude\\)(\\([^ \t\n)]*\\)" 2)
     ;; ("Classes" "^.*setClass(\\(.*\\)," 1)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -705,10 +705,11 @@ Return nil if point is not in a function, otherwise point."
   ;; don't use syntax classes, screws egrep
   '(("Function (_)" "[ \t]*function[ \t]+\\(_[^ \t\n]*\\)" 1)
     ("Function" "^[ \t]*function[ \t]+\\([^_][^\t\n]*\\)" 1)
-    ("Const" "[ \t]*const \\([^ \t\n]*\\)" 1)
-    ("Type"  "^[ \t]*[a-zA-Z0-9_]*type[a-zA-Z0-9_]* \\([^ \t\n]*\\)" 1)
-    ("Require"      " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)
-    ("Include"      " *\\(\\binclude\\)(\\([^ \t\n)]*\\)" 2)
+    ("Function" "^[ \t]*\\(\\(@.+ \\)?[_a-zA-Z0-9]+\(.*\)\\) *= " 1)
+    ("Const" "^[ \t]*const \\([^ \t\n]*\\) *= " 1)
+    ("Struct" "^[ \t]*\\(\\(mutable \\)*struct [^ \t\n]*\\)" 1)
+    ("Require" " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)
+    ("Include" " *\\(\\binclude\\)(\\([^ \t\n)]*\\)" 2)
     ;; ("Classes" "^.*setClass(\\(.*\\)," 1)
     ;; ("Coercions" "^.*setAs(\\([^,]+,[^,]*\\)," 1) ; show from and to
     ;; ("Generics" "^.*setGeneric(\\([^,]*\\)," 1)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -705,7 +705,7 @@ Return nil if point is not in a function, otherwise point."
   ;; don't use syntax classes, screws egrep
   '(("Function (_)" "[ \t]*function[ \t]+\\(_[^ \t\n]*\\)" 1)
     ("Function" "^[ \t]*function[ \t]+\\([^_][^\t\n]*\\)" 1)
-    ("Function" "^[ \t]*\\(\\(@.+ \\)?[_a-zA-Z0-9]+\(.*\)\\) *= " 1)
+    ("Function" "^[ \t]*\\(\\(@.+ \\)?[!\._a-zA-Z0-9]+\(.*\).*\\) = " 1)
     ("Const" "^[ \t]*const \\([^ \t\n]*\\) *= " 1)
     ("Struct" "^[ \t]*\\(\\(mutable \\)*struct [^ \t\n]*\\)" 1)
     ("Require" " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -703,10 +703,10 @@ Return nil if point is not in a function, otherwise point."
 ;;; IMENU
 (defvar julia-imenu-generic-expression
   ;; don't use syntax classes, screws egrep
-  '(("Function (_)" "^[ \t]*function[ \t]+\\(_.*?\\)\\( +end\\|$\\)" 1)
-    ("Function (_)" "^[ \t]*\\(\\(@.+ \\)?_[!\._a-zA-Z0-9]+\(.*\).*\\) = " 1)
-    ("Function" "^[ \t]*function[ \t]+\\([^_].*?\\)\\( +end\\|$\\)" 1)
-    ("Function" "^[ \t]*\\(\\(@.+ \\)?\(?<!_\)[!\.a-zA-Z0-9][!\._a-zA-Z0-9]*\(.*\).*\\) =" 1)
+  '(("Function (_)" "^[ \t]*\\(@.+ \\)?function[ \t]+\\(_.*?\\)\\( +end\\|$\\)" 2)
+    ("Function (_)" "^[ \t]*\\(@.+ \\)?\\(_[!\._a-zA-Z0-9]+\(.*\).*\\) = " 2)
+    ("Function" "^[ \t]*\\(@.+ \\)?function[ \t]+\\([^_].*?\\)\\( +end\\|$\\)" 2)
+    ("Function" "^[ \t]*\\(@.+ \\)?\\([!\.a-zA-Z0-9][!\._a-zA-Z0-9]*\(.*\).*\\) = " 2)
     ("Const" "^[ \t]*const \\([^ \t\n]*\\) *= " 1)
     ("Struct" "^[ \t]*\\(\\(mutable \\)*struct [^ \t\n]*\\)" 1)
     ("Require" " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -703,9 +703,10 @@ Return nil if point is not in a function, otherwise point."
 ;;; IMENU
 (defvar julia-imenu-generic-expression
   ;; don't use syntax classes, screws egrep
-  '(("Function (_)" "[ \t]*function[ \t]+\\(_[^ \t\n]*\\)" 1)
-    ("Function" "^[ \t]*function[ \t]+\\([^_][^\t\n]*\\)" 1)
-    ("Function" "^[ \t]*\\(\\(@.+ \\)?[!\._a-zA-Z0-9]+\(.*\).*\\) = " 1)
+  '(("Function (_)" "^[ \t]*function[ \t]+\\(_.*?\\)\\( +end\\|$\\)" 1)
+    ("Function (_)" "^[ \t]*\\(\\(@.+ \\)?_[!\._a-zA-Z0-9]+\(.*\).*\\) = " 1)
+    ("Function" "^[ \t]*function[ \t]+\\([^_].*?\\)\\( +end\\|$\\)" 1)
+    ("Function" "^[ \t]*\\(\\(@.+ \\)?\(?<!_\)[!\.a-zA-Z0-9][!\._a-zA-Z0-9]*\(.*\).*\\) =" 1)
     ("Const" "^[ \t]*const \\([^ \t\n]*\\) *= " 1)
     ("Struct" "^[ \t]*\\(\\(mutable \\)*struct [^ \t\n]*\\)" 1)
     ("Require" " *\\(\\brequire\\)(\\([^ \t\n)]*\\)" 2)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -755,7 +755,7 @@ Return nil if point is not in a function, otherwise point."
          (group (zero-or-one "mutable" space) "struct" space (one-or-more alnum)))))
 
 ;;; IMENU
-(setq julia-imenu-generic-expression
+(defvar julia-imenu-generic-expression
   ;; don't use syntax classes, screws egrep
   `(("Function" ,julia-imenu-public-multiline-fn 1)
     ("Function" ,julia-imenu-public-singleline-fn 1)


### PR DESCRIPTION
Hi, I'm using this in my config, and while it's probably not perfect, I think it's better than the status quo:

This PR
- adds one-line fn support to imenu, including `@xyz` annotations: `@inline x(y) = ...`
- removes type (deprecated for newer Julia versions?)
- adds support for (mutable) struct instead: `mutable struct S{T} where T`
- requires `const =` and `^` s.t. const isn't accidentally parsed in strings etc.: `   const xzy =`

You can try it out by running `M-x imenu` in a `julia-mode` buffer.