### PR TITLE
Apply proper syntax to triple-quoted cmds

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -532,8 +532,17 @@ end")
     (julia--should-font-lock string 74 font-lock-type-face) ; B
     ))
 
+(ert-deftest julia--test-single-quote-string-font-lock ()
+  "Test that single quoted strings are font-locked correctly even with escapes."
+  ;; Issue #15
+  (let ((s1 "\"a\\\"b\"c"))
+    (julia--should-font-lock s1 2 font-lock-string-face)
+    (julia--should-font-lock s1 5 font-lock-string-face)
+    (julia--should-font-lock s1 7 nil)))
+
 (ert-deftest julia--test-triple-quote-string-font-lock ()
   "Test that triple quoted strings are font-locked correctly even with escapes."
+  ;; Issue #15
   (let ((s1 "\"\"\"a\\\"\\\"\"b\"\"\"d")
         (s2 "\"\"\"a\\\"\"\"b\"\"\"d")
         (s3 "\"\"\"a```b\"\"\"d")

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -532,6 +532,47 @@ end")
     (julia--should-font-lock string 74 font-lock-type-face) ; B
     ))
 
+(ert-deftest julia--test-triple-quote-string-font-lock ()
+  "Test that triple quoted strings are font-locked correctly even with escapes."
+  (let ((s1 "\"\"\"a\\\"\\\"\"b\"\"\"d")
+        (s2 "\"\"\"a\\\"\"\"b\"\"\"d")
+        (s3 "\"\"\"a```b\"\"\"d")
+        (s4 "\\\"\"\"a\\\"\"\"b\"\"\"d")
+        (s5 "\"\"\"a\\\"\"\"\"b"))
+    (julia--should-font-lock s1 4 font-lock-string-face)
+    (julia--should-font-lock s1 10 font-lock-string-face)
+    (julia--should-font-lock s1 14 nil)
+    (julia--should-font-lock s2 4 font-lock-string-face)
+    (julia--should-font-lock s2 9 font-lock-string-face)
+    (julia--should-font-lock s2 13 nil)
+    (julia--should-font-lock s3 4 font-lock-string-face)
+    (julia--should-font-lock s3 8 font-lock-string-face)
+    (julia--should-font-lock s3 12 nil)
+    (julia--should-font-lock s4 5 font-lock-string-face)
+    (julia--should-font-lock s4 10 font-lock-string-face)
+    (julia--should-font-lock s4 14 nil)
+    (julia--should-font-lock s5 4 font-lock-string-face)
+    (julia--should-font-lock s5 10 nil)))
+
+(ert-deftest julia--test-triple-quote-cmd-font-lock ()
+  "Test that triple-quoted cmds are font-locked correctly even with escapes."
+  (let ((s1 "```a\\`\\``b```d")
+        (s2 "```a\\```b```d")
+        (s3 "```a\"\"\"b```d")
+        (s4 "\\```a\\```b```d"))
+    (julia--should-font-lock s1 4 font-lock-string-face)
+    (julia--should-font-lock s1 10 font-lock-string-face)
+    (julia--should-font-lock s1 14 nil)
+    (julia--should-font-lock s2 4 font-lock-string-face)
+    (julia--should-font-lock s2 9 font-lock-string-face)
+    (julia--should-font-lock s2 13 nil)
+    (julia--should-font-lock s3 4 font-lock-string-face)
+    (julia--should-font-lock s3 8 font-lock-string-face)
+    (julia--should-font-lock s3 12 nil)
+    (julia--should-font-lock s4 5 font-lock-string-face)
+    (julia--should-font-lock s4 10 font-lock-string-face)
+    (julia--should-font-lock s4 14 nil)))
+
 ;;; Movement
 (ert-deftest julia--test-beginning-of-defun-assn-1 ()
   "Point moves to beginning of single-line assignment function."
@@ -695,6 +736,14 @@ hello world
     ;; If triple-quoted strings improperly syntax-propertized as 3
     ;; single-quoted strings, this will show string starting at pos 3
     ;; instead of 1.
+    (should (= 1 (nth 8 (syntax-ppss 5))))))
+
+(ert-deftest julia--test-triple-quoted-cmd-syntax ()
+  (with-temp-buffer
+    (julia-mode)
+    (insert "```
+hello world
+```")
     (should (= 1 (nth 8 (syntax-ppss 5))))))
 
 (ert-deftest julia--test-backslash-syntax ()

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -113,9 +113,8 @@
             (syntax whitespace)
             bol)
         (group "'")
-        (group
-         (or (repeat 0 8 (not (any "'"))) (not (any "\\"))
-             "\\\\"))
+        (or (repeat 0 8 (not (any "'"))) (not (any "\\"))
+            "\\\\")
         (group "'"))))
 
 (defconst julia-hanging-operator-regexp
@@ -317,9 +316,10 @@
     (0 (unless (nth 3 (save-excursion (syntax-ppss (match-beginning 0))))
          (string-to-syntax "."))))
    (julia-char-regex
-    (1 "\"")                    ; Treat ' as a string delimiter.
-    (2 ".")                     ; Don't highlight anything between.
-    (3 "\"")))) ; Treat the last " in """ as a string delimiter.
+    ;; treat ' in 'c' as string-delimiter
+    (1 "\"")
+    (2 "\""))))
+
 
 (defun julia-in-comment (&optional syntax-ppss)
   "Return non-nil if point is inside a comment using SYNTAX-PPSS.


### PR DESCRIPTION
This is necessary cleanup before #132 could be attempted and should also make triple-backticks work correctly which has never been true before.

This also appears to have fixed all the corner-cases with escapes in strings.

Closes #15, closes #119