### PR TITLE
Rec/quoted quote

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -88,13 +88,6 @@ matching line or end of match if END is non-nil.  Optional ARG is passed to FUN.
                                       (point-at-bol)))
                            ,to)))))
 
-(defmacro julia--should-regex-char-const (text)
-  "(string-match julia-char-regex `text') should return text"
-  `(with-temp-buffer
-     (julia-mode)
-     (and (= 0 (string-match julia-char-regex ,text))
-	  (string= ,text (match-string 0 ,text)))))
-
 ;;; indent tests
 
 (ert-deftest julia--test-indent-if ()
@@ -489,6 +482,18 @@ identity"
 a = \"#\" # |>
 identity"))
 
+(ert-deftest julia--test-indent-quoted-single-quote ()
+  "We should indent after seeing a character constant containing a single quote character."
+  (julia--should-indent "
+if c in ('\'')
+s = \"$c$c\"*string[startpos:pos]
+end
+" "
+if c in ('\'')
+    s = \"$c$c\"*string[startpos:pos]
+end
+"))
+
 ;;; font-lock tests
 
 (ert-deftest julia--test-symbol-font-locking-at-bol ()
@@ -812,28 +817,6 @@ hello world
     (should (equal
              (string-to-syntax "\\")
              (syntax-after 13)))))
-
-(ert-deftest julia--test-indent-quoted-single-quote ()
-  "We should indent after seeing a character constant containing a single quote character."
-  (julia--should-indent "
-if c in ('\'')
-s = \"$c$c\"*string[startpos:pos]
-end
-" "
-if c in ('\'')
-s = \"$c$c\"*string[startpos:pos]
-end
-"))
-
-(ert-deftest julia--test-quoted-char-const-1 () (julia--should-regex-char-const "'\\''"))
-(ert-deftest julia--test-quoted-char-const-2 () (julia--should-regex-char-const "'\\\"'"))
-(ert-deftest julia--test-quoted-char-const-3 () (julia--should-regex-char-const "'\\\\'"))
-(ert-deftest julia--test-quoted-char-const-4 () (julia--should-regex-char-const "'\\0'"))
-(ert-deftest julia--test-quoted-char-const-5 () (julia--should-regex-char-const "'\\xff'"))
-(ert-deftest julia--test-quoted-char-const-6 () (julia--should-regex-char-const "'\\u7f'"))
-(ert-deftest julia--test-quoted-char-const-7 () (julia--should-regex-char-const "'\\U7f7f7f'"))
-(ert-deftest julia--test-quoted-char-const-8 () (julia--should-regex-char-const "'\\n'"))
-(ert-deftest julia--test-quoted-char-const-9 () (julia--should-regex-char-const "'n'"))
 
 ;;;
 ;;; run all tests

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -633,7 +633,8 @@ end
     (julia--should-font-lock s1 10 nil)))
 
 (ert-deftest julia--test-char-const-font-lock ()
-  (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'a'" "'z'"))
+  (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" 
+               "'\\Uabcdef01'" "'\\n'" "'a'" "'z'" "'''"))
     (let ((c (format " %s " c)))
       (progn
         (julia--should-font-lock c 1 nil)

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -806,6 +806,18 @@ hello world
              (string-to-syntax "\\")
              (syntax-after 13)))))
 
+(ert-deftest julia--test-indent-quoted-single-quote ()
+  "We should indent after seeing a character constant containing a single quote character."
+  (julia--should-indent "
+if c in ('\'')
+s = \"$c$c\"*string[startpos:pos]
+end
+" "
+if c in ('\'')
+s = \"$c$c\"*string[startpos:pos]
+end
+"))
+
 ;;;
 ;;; run all tests
 ;;;

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -634,7 +634,13 @@ end
 
 (ert-deftest julia--test-char-const-font-lock ()
   (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'\\alpha'" "'a'"  "'z'"))
-    (julia--should-font-lock c 1 font-lock-string-face)))
+    (let ((c (format " %s " c)))
+      (progn
+        (julia--should-font-lock c 1 nil)
+        (julia--should-font-lock c 2 font-lock-string-face)
+        (julia--should-font-lock c (- (length c) 1) font-lock-string-face)
+        (julia--should-font-lock c (length c) nil)
+    ))))
 
 ;;; Movement
 (ert-deftest julia--test-beginning-of-defun-assn-1 ()

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -632,6 +632,10 @@ end
     (julia--should-font-lock s1 4 nil)
     (julia--should-font-lock s1 10 nil)))
 
+(ert-deftest julia--test-char-const-font-log ()
+  (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'\\alpha'" "'a'"  "'z'"))
+    (julia--should-font-lock c 1 font-lock-string-face)))
+
 ;;; Movement
 (ert-deftest julia--test-beginning-of-defun-assn-1 ()
   "Point moves to beginning of single-line assignment function."

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -633,7 +633,7 @@ end
     (julia--should-font-lock s1 10 nil)))
 
 (ert-deftest julia--test-char-const-font-lock ()
-  (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'\\alpha'" "'a'"  "'z'"))
+  (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'a'" "'z'"))
     (let ((c (format " %s " c)))
       (progn
         (julia--should-font-lock c 1 nil)

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -632,7 +632,7 @@ end
     (julia--should-font-lock s1 4 nil)
     (julia--should-font-lock s1 10 nil)))
 
-(ert-deftest julia--test-char-const-font-log ()
+(ert-deftest julia--test-char-const-font-lock ()
   (dolist (c '("'\\''" "'\\\"'" "'\\\\'" "'\\010'" "'\\xfe'" "'\\uabcd'" "'\\Uabcdef01'" "'\\n'" "'\\alpha'" "'a'"  "'z'"))
     (julia--should-font-lock c 1 font-lock-string-face)))
 

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -109,11 +109,17 @@
             (syntax open-parenthesis)
             (syntax whitespace)
             bol)
-        (group "'")
-        (or (not (any "\\'"))
-	    (seq "\\" (or (repeat 1 9 (not (any "\\'")))
-			  (any "\\'"))))
-        (group "'"))))
+        (group "'")                     ; start single quote of character constant
+        (or                             ; two alternatives
+         (not (any "\\'"))              ; one character, not single quote or backslash
+	     (seq "\\"                      ; sequence of a backslash followed by ...
+              (or                       ; four alternatives
+               (any "\\'\"?abfnrtv")    ; single character escape
+               (repeat 1 3 (any "0-7")) ; octal escape
+               (seq 'x' (repeat 1 8 hex))     ; hex escape
+               (seq 'u' (repeat 1 4 hex))     ; unicode escape
+               (seq 'U' (repeat 1 8 hex)))))  ; extended unicode escaple
+        (group "'"))))                  ; end single quote of character constant
 
 (defconst julia-hanging-operator-regexp
   ;; taken from julia-parser.scm

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -113,7 +113,7 @@
         (or                             ; two alternatives
          (not (any "\\'"))              ; one character, not single quote or backslash
 	     (seq "\\"                      ; sequence of a backslash followed by ...
-              (or                       ; four alternatives
+              (or                       ; five alternatives
                (any "\\'\"?abfnrtv")    ; single character escape
                (repeat 1 3 (any "0-7")) ; octal escape
                (seq 'x' (repeat 1 8 hex))     ; hex escape

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -111,7 +111,7 @@
             bol)
         (group "'")        ; start single quote of character constant
         (or                ; two alternatives
-         (not (any "\\'")) ; one character, not single quote or backslash
+         (not (any "\\"))  ; one character, not backslash
 	     (seq "\\"         ; sequence of a backslash followed by ...
               (or          ; five alternatives
                (any "\\'\"abfnrtv")          ; single character escape

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -109,17 +109,17 @@
             (syntax open-parenthesis)
             (syntax whitespace)
             bol)
-        (group "'")                     ; start single quote of character constant
-        (or                             ; two alternatives
-         (not (any "\\'"))              ; one character, not single quote or backslash
-	     (seq "\\"                      ; sequence of a backslash followed by ...
-              (or                       ; five alternatives
-               (any "\\'\"?abfnrtv")    ; single character escape
-               (repeat 1 3 (any "0-7")) ; octal escape
-               (seq "x" (repeat 1 8 hex))     ; hex escape
-               (seq "u" (repeat 1 4 hex))     ; unicode escape
-               (seq "U" (repeat 1 8 hex)))))  ; extended unicode escaple
-        (group "'"))))                  ; end single quote of character constant
+        (group "'")        ; start single quote of character constant
+        (or                ; two alternatives
+         (not (any "\\'")) ; one character, not single quote or backslash
+	     (seq "\\"         ; sequence of a backslash followed by ...
+              (or          ; five alternatives
+               (any "\\'\"?abfnrtv")         ; single character escape
+               (repeat 1 3 (any "0-7"))      ; octal escape
+               (seq "x" (repeat 1 8 hex))    ; hex escape
+               (seq "u" (repeat 1 4 hex))    ; unicode escape
+               (seq "U" (repeat 1 8 hex))))) ; extended unicode escaple
+        (group "'"))))     ; end single quote of character constant
 
 (defconst julia-hanging-operator-regexp
   ;; taken from julia-parser.scm

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -110,15 +110,9 @@
             (syntax whitespace)
             bol)
         (group "'")
-	(or 
-	 (not (any "\\'"))		; single character, not \ or '
-	 (seq ?\\ (or			; \ followed by ...
-		   (repeat 1 3 (any "0-7"))	   ; octal escape
-		   (seq ?x (repeat 1 2 (any hex))) ; hex escape
-		   (seq ?u (repeat 1 4 (any hex))) ; unicode escape
-		   (seq ?U (repeat 1 8 (any hex))) ; extended unicode escape
-		   (not (any "0-7xuU")))	   ; anything else
-	      ))
+        (or (not (any "\\'"))
+	    (seq "\\" (or (repeat 1 9 (not (any "\\'")))
+			  (any "\\'"))))
         (group "'"))))
 
 (defconst julia-hanging-operator-regexp

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -110,8 +110,15 @@
             (syntax whitespace)
             bol)
         (group "'")
-        (or (repeat 0 8 (not (any "'"))) (not (any "\\"))
-            "\\\\")
+	(or 
+	 (not (any "\\'"))		; single character, not \ or '
+	 (seq ?\\ (or			; \ followed by ...
+		   (repeat 1 3 (any "0-7"))	   ; octal escape
+		   (seq ?x (repeat 1 2 (any hex))) ; hex escape
+		   (seq ?u (repeat 1 4 (any hex))) ; unicode escape
+		   (seq ?U (repeat 1 8 (any hex))) ; extended unicode escape
+		   (not (any "0-7xuU")))	   ; anything else
+	      ))
         (group "'"))))
 
 (defconst julia-hanging-operator-regexp

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -114,11 +114,11 @@
          (not (any "\\'")) ; one character, not single quote or backslash
 	     (seq "\\"         ; sequence of a backslash followed by ...
               (or          ; five alternatives
-               (any "\\'\"?abfnrtv")         ; single character escape
+               (any "\\'\"abfnrtv")          ; single character escape
                (repeat 1 3 (any "0-7"))      ; octal escape
-               (seq "x" (repeat 1 8 hex))    ; hex escape
+               (seq "x" (repeat 1 2 hex))    ; hex escape
                (seq "u" (repeat 1 4 hex))    ; unicode escape
-               (seq "U" (repeat 1 8 hex))))) ; extended unicode escaple
+               (seq "U" (repeat 1 8 hex))))) ; extended unicode escape
         (group "'"))))     ; end single quote of character constant
 
 (defconst julia-hanging-operator-regexp

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -116,9 +116,9 @@
               (or                       ; five alternatives
                (any "\\'\"?abfnrtv")    ; single character escape
                (repeat 1 3 (any "0-7")) ; octal escape
-               (seq 'x' (repeat 1 8 hex))     ; hex escape
-               (seq 'u' (repeat 1 4 hex))     ; unicode escape
-               (seq 'U' (repeat 1 8 hex)))))  ; extended unicode escaple
+               (seq "x" (repeat 1 8 hex))     ; hex escape
+               (seq "u" (repeat 1 4 hex))     ; unicode escape
+               (seq "U" (repeat 1 8 hex)))))  ; extended unicode escaple
         (group "'"))))                  ; end single quote of character constant
 
 (defconst julia-hanging-operator-regexp


### PR DESCRIPTION
I think this solves https://github.com/JuliaEditorSupport/julia-emacs/issues/142 by simply rewriting `julia-char-regex`.  The regex didn't actually recognize `'\'`' as a character constant as it was written.  It could still be wrong.   Added a test for my particular case.

Sorry, I should have rebased or something to squash  the intermediate commits.