### PR TITLE
Indent imports from submodule correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- fix indentation of submodule imports
+
 # 0.4
 
 - increase lookback ([#98](https://github.com/JuliaEditorSupport/julia-emacs/pull/98)), fixes [#5](https://github.com/JuliaEditorSupport/julia-emacs/issues/5)

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -386,6 +386,15 @@ notpartofit"
    "using Foo: bar ,
     baz,
     quux
+notpartofit")
+  (julia--should-indent
+   "using Foo.Bar: bar ,
+baz,
+quux
+notpartofit"
+   "using Foo.Bar: bar ,
+    baz,
+    quux
 notpartofit"))
 
 (ert-deftest julia--test-indent-anonymous-function ()

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -428,6 +428,8 @@ symbol, gives up when this is not true."
             (setf module (match-string-no-properties 1))))
          ((looking-at (rx (* (or word (syntax symbol))) (0+ space) ","))
           (when module (setf done 'broken)))
+         ((looking-at (rx (* (or word (syntax symbol))) "."))
+          (setf module (concat (match-string-no-properties 0) module)))
          (t (setf done 'broken)))))
     (if (eq done 'broken)
         nil


### PR DESCRIPTION
`julia-mode` cannot handle `using Module.Submodule: ...` statements correctly, symbols aren't indented as they are supposed to be. This simple fix takes care of that.