### PR TITLE
Fix issue in keyword indentation with compound keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix issue in keyword indentation with compound keywords ([#159](https://github.com/JuliaEditorSupport/julia-emacs/pull/159))
+
 # 0.4
 
 - increase lookback ([#98](https://github.com/JuliaEditorSupport/julia-emacs/pull/98)), fixes [#5](https://github.com/JuliaEditorSupport/julia-emacs/issues/5)

--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -581,6 +581,34 @@ var = func(begin
            end
            )"))
 
+(ert-deftest julia--test-indent-block-compound-keywords ()
+  "We should indent on compound keywords inside a block."
+  (julia--should-indent "
+begin
+abstract type MyType end
+test
+end" "
+begin
+    abstract type MyType end
+    test
+end"))
+
+(ert-deftest julia--test-indent-block-compound-keywords-with-nesting ()
+  "We should indent on compound keywords and again inside them."
+  (julia--should-indent "
+begin
+abstract type MyType
+test1
+end
+test2
+end" "
+begin
+    abstract type MyType
+        test1
+    end
+    test2
+end"))
+
 ;;; font-lock tests
 
 (ert-deftest julia--test-symbol-font-locking-at-bol ()


### PR DESCRIPTION
While playing around with Julia macros, I noticed that `abstract type` definitions inside a begin-end block were breaking the indentation in my Emacs.

I've never written anything in Emacs Lisp before, but the broken indentation was annoying me enough that I figured out how to fix it.

On closer inspection, I determined that the issue is with `julia-last-open-block-pos` and `julia-at-keyword`. The block position function determines the nesting level by scanning code preceding `point` one s-expressions at a time, keeping count of matched block starting and ending keywords. The `julia-at-keyword` function tries to match on keywords listed in `julia-block-start-keywords`, but unfortunately the matching doesn't quite work with _compound keywords_ made up of more than one word.

Because `julia-at-keyword` uses `(current-word)`, and because `abstract` and `type` are parsed as separate words, the matching misses the compound keyword `abstract type` (and `primitive type` and `mutable struct`). This results in the begin/end counting algorithm missing the compound keyword block beginnings, breaking the indentation.

This PR fixes this issue by introducing a new matching function specifically for compound keywords, `julia-at-compound-keyword`. This function looks at the current word and the one preceding it, and determines whether `point` is on the second word of a compound keyword. To make use of this function, I propose splitting the keyword list in two parts, with the compound words in their own list. The new function is applied as an additional clause in the block begin/end counting function.

I've included two tests that demonstrate the desired behaviour.

The performance cost from running the extra function should be negligible, though it is called for every s-expression step inside the matching algorithm.