### PR TITLE
Generalise julia-indent-hanging to cover more cases

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -486,6 +486,119 @@ identity"
 a = \"#\" # |>
 identity"))
 
+(ert-deftest julia--test-indent-complex-hanging ()
+  "Test indentation in more complex hanging indentation situations."
+  (julia--should-indent
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2]) |>
+do_stuff
+"
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2]) |>
+op1 |>
+op2 |>
+op3
+"
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2]) |>
+    op1 |>
+    op2 |>
+    op3
+")
+  (julia--should-indent
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+:longname3, :longname4]) |>
+do_stuff
+"
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+                                        :longname3, :longname4]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+:longnameA, :longnameB,
+:longnameC, :longnameD,
+:longnameE, :longnameF,
+:longname3, :longname4]) |>
+do_stuff
+"
+   "
+sample = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+                                        :longnameA, :longnameB,
+                                        :longnameC, :longnameD,
+                                        :longnameE, :longnameF,
+                                        :longname3, :longname4]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+sample2 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+:longname3, :longname4
+:longname5, :longname5]) |>
+do_stuff
+"
+   "
+sample2 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+                                         :longname3, :longname4
+                                         :longname5, :longname5]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+sample3 =
+@pipe leftjoin(df1, df2, on = [:longname1,
+:longname2, :longname3, :longname4]) |>
+do_stuff
+"
+   "
+sample3 =
+    @pipe leftjoin(df1, df2, on = [:longname1,
+                                   :longname2, :longname3, :longname4]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+sample4 =
+@pipe leftjoin(df1,
+df2, on = [:longname1, :longname2,
+:longname3, :longname4]) |>
+do_stuff
+"
+   "
+sample4 =
+    @pipe leftjoin(df1,
+                   df2, on = [:longname1, :longname2,
+                              :longname3, :longname4]) |>
+    do_stuff
+")
+  (julia--should-indent
+   "
+begin
+begin
+temporary = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+ :longname3, :longname4]) |>
+op
+end
+end
+"
+   "
+begin
+    begin
+        temporary = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
+                                                   :longname3, :longname4]) |>
+            op
+    end
+end
+"))
+
 (ert-deftest julia--test-indent-quoted-single-quote ()
   "We should indent after seeing a character constant containing a single quote character."
   (julia--should-indent "


### PR DESCRIPTION
Having looked at the indentation code for a bit, I decided to tackle issue #155 just to learn more about this stuff.

The reported issue is concerned with indentation in situations where an operator is the last token on the line.

In ESS, R code is formatted like so:

```r
# ESS 18.10.2

sample1 <- left_join(df1, df2, by = c("longname1", "longname2", "longname3", "longname4")) %>%
    do_stuff

sample2 <-left_join(df1, df2, by = c("longname1", "longname2",
                                     "longname3", "longname4",
                                     "longname5", "longname6")) %>%
    do_stuff

sample3 <-
    left_join(df1, df2, by = c("longname1",
                               "longname2", "longname3", "longname4")) %>%
    do_stuff

sample4 <-
    left_join(df1,
              df2, by = c("longname1", "longname2",
                          "longname3", "longname4")) %>%
    do_stuff
```

Similar code in Julia is currently formatted like so:

```julia
sample1 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2, :longname3, :longname4]) |>
    do_stuff

sample2 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
                                         :longname3, :longname4,
                                         :longname5, :longname6]) |>
                                             do_stuff

sample3 =
    @pipe leftjoin(df1, df2, on = [:longname1,
                                   :longname2, :longname3, :longname4]) |>
                                       do_stuff

sample4 =
    @pipe leftjoin(df1,
                   df2, on = [:longname1, :longname2,
                              :longname3, :longname4]) |>
                                  do_stuff
```

In other words, in some cases featuring the hanging operator -- here the pipe, `|>` -- julia-mode is not indenting the subsequent line as neatly as ESS indents R.

This PR generalises the existing hanging operator indentation routine, `julia-indent-hanging`, by iterating over the hanging line scanner and by introducing an additional check for detecting split parentheses. (This is powered by the existing `julia-parent-indent` function.)

This fixes indentation for cases where:
 
1. two hanging operators are NOT on adjacent lines, OR

2. a multi-line parenthesis expression is followed by a hanging operator.

With this PR, the above examples indent as below, which is arguably nicer. Other indentation should not be affected.

```julia
sample1 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2, :longname3, :longname4]) |>
    do_stuff

sample2 = @pipe leftjoin(df1, df2, on = [:longname1, :longname2,
                                         :longname3, :longname4,
                                         :longname5, :longname6]) |>
    do_stuff

sample3 =
    @pipe leftjoin(df1, df2, on = [:longname1,
                                   :longname2, :longname3, :longname4]) |>
    do_stuff

sample4 =
    @pipe leftjoin(df1,
                   df2, on = [:longname1, :longname2,
                              :longname3, :longname4]) |>
    do_stuff
```