### PR TITLE
Improve highlighting of `in`.

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -189,8 +189,8 @@
 (defconst julia-unquote-regex
   "\\(\\s(\\|\\s-\\|-\\|[,%=<>\\+*/?&|!\\^~\\\\;:]\\|^\\)\\($[a-zA-Z0-9_]+\\)")
 
-(defconst julia-forloop-in-regex
-  "for +.*[^
+(defconst julia-in-regex
+  " +.*[^
 ].* \\(in\\)\\(\\s-\\|$\\)+")
 
 (defconst julia--forloop-=-regex
@@ -282,7 +282,7 @@
     'font-lock-constant-face)
    (cons "ccall" 'font-lock-builtin-face)
    (list julia-unquote-regex 2 'font-lock-constant-face)
-   (list julia-forloop-in-regex 1 'font-lock-keyword-face)
+   (list julia-in-regex 1 'font-lock-keyword-face)
    (list julia--forloop-=-regex 1 'font-lock-keyword-face)
    (list julia-ternary-regex (list 1 'font-lock-keyword-face) (list 2 'font-lock-keyword-face))
    (list julia-function-regex 1 'font-lock-function-name-face)


### PR DESCRIPTION
This highlights both `in` keywords in multi-iterable `for` loops (#148), and adds highlighting in the cases where `in` is used to check if an element is contained in an array, as in `if 2 in [1, 2, 3]`.
