### PR TITLE
Remove stray backtick in MELPA LISP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unless you want to develop this package, it is recommended that you use it from 
 
 ```elisp
 (package-install 'julia-mode)
-(require 'julia-mode)`
+(require 'julia-mode)
 ```
 
 ### Installing from Source


### PR DESCRIPTION
Emacs will not parse MELPA code with cut-and-paste due to stray backtick. Removed it.