### PR TITLE
Provide a safe range for julia-indent-offset

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -49,6 +49,7 @@
 
 (defcustom julia-indent-offset 4
   "Number of spaces per indentation level."
+  :safe (lambda (n) (and (> n 1) (<= n 8)))
   :type 'integer)
 
 (defface julia-macro-face


### PR DESCRIPTION
Projects may wish to customize `julia-indent-offset` as either file-local or directory-local (`.dir-locals.el`) variables. Without the `:safe` form in `defcustom`, this causes Emacs to pop up an annoying warning. The proposed change gives a reasonable indentation range (no one should indent under 2 spaces or over 8).