### PR TITLE
Fix escaping in julia-in-string docstring

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -329,7 +329,7 @@ Handles both single-line and multi-line comments."
 (defun julia-in-string (&optional syntax-ppss)
   "Return non-nil if point is inside a string using SYNTAX-PPSS.
 Note this is Emacs' notion of what is highlighted as a string.
-As a result, it is true inside \"foo\", `foo` and 'f'."
+As a result, it is true inside \"foo\", \\=`foo\\=` and \\='f\\='."
   (nth 3 (or syntax-ppss (syntax-ppss))))
 
 (defun julia-in-brackets ()


### PR DESCRIPTION
Hi!

Before this commit, the docstring of `julia-in-string` was rendered as:

<img width="504" alt="Captura de Tela 2023-01-16 às 14 51 52" src="https://user-images.githubusercontent.com/1068295/212740852-47ccba8f-73d6-4d31-a391-aa8b1c504a80.png">

After, it is rendered as:

<img width="506" alt="Captura de Tela 2023-01-16 às 14 52 26" src="https://user-images.githubusercontent.com/1068295/212740874-c35fed73-39e5-428b-9920-26f457fefc0d.png">

This commit also suppresses a warning in Emacs 29 related to unescaped `'`:

> NEWS from Emacs 29

> *** Byte compilation will now warn about some quoting mistakes in docstrings.
> When writing code snippets that contains the "'" character (APOSTROPHE),
> that quote character has to be escaped to avoid Emacs displaying it as
> "’" (LEFT SINGLE QUOTATION MARK), which would make code examples like>
> 
>     (setq foo '(1 2 3))
> 
> invalid.  Emacs will now warn during byte compilation if it seems
> something like that, and also warn about when using RIGHT/LEFT SINGLE
> QUOTATION MARK directly.  In both these cases, if these characters
> should really be present in the docstring, they should be quoted with
> "\=".

Closes #180
