### PR TITLE
option to restore previous TAB behavior

### DIFF
--- a/julia-mode.el
+++ b/julia-mode.el
@@ -938,12 +938,10 @@ buffer where the LaTeX symbol starts."
 When multiple options match, ask the user to clarify via `completing-read', unless there is a complete match and `julia-latexsub-greedy' is `t'."
   (when-let (beg (julia--latexsub-start-symbol))
     (let ((partial (buffer-substring-no-properties beg (point))))
-      (message "partial %s" partial)
       (when-let (replacements (gethash partial julia-mode--latexsubs-partials))
-        (message "replacements %s" (prin1 replacements))
         (let* ((complete-match (member partial replacements))
                (replacement (cond ((and complete-match julia-latexsub-greedy) partial)
-                                  ((cdr replacements) (gethash (completing-read "LaTeX completions: " replacements) julia-mode-latexsubs))
+                                  ((cdr replacements) (completing-read "LaTeX completions: " replacements))
                                   (t (car replacements)))))
           (cons beg replacement))))))
 

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -951,16 +951,16 @@ When multiple options match, ask the user to clarify via `julia-latexsub-selecto
     (let ((partial (buffer-substring-no-properties beg (point))))
       (when-let (replacements (gethash partial julia-mode--latexsubs-partials))
         (let* ((complete-match (member partial replacements))
-               (replacement (cond
-                             ;; complete match w/ greedy
-                             ((and complete-match julia-latexsub-greedy) partial)
-                             ;; multiple replacements, ask user
-                             ((cdr replacements) (funcall julia-latexsub-selector replacements))
-                             ;; single replacement, pick that
-                             (t (car replacements)))))
-          (cons beg replacement))))))
+               (latex (cond
+                       ;; complete match w/ greedy
+                       ((and complete-match julia-latexsub-greedy) partial)
+                       ;; multiple replacements, ask user
+                       ((cdr replacements) (funcall julia-latexsub-selector replacements))
+                       ;; single replacement, pick that
+                       (t (car replacements)))))
+          (cons beg latex))))))
 
-(defun julia-latexsub-or-indent  (arg)
+(defun julia-latexsub-or-indent (arg)
   "Either indent according to Julia mode conventions or perform a LaTeX-like symbol substution.
 
 When multiple options match, ask the user to clarify via `julia-latexsub-selector', unless there is a complete match and `julia-latexsub-greedy' is `t'.
@@ -969,7 +969,7 @@ Presently, this is not the default. Enable with eg
 
 (define-key julia-mode-map (kbd \"TAB\") 'julia-latexsub-or-indent)
 
- in your `julia-mode-hook'."
+eg in your `julia-mode-hook'."
   (interactive "*i")
   (if-let (replacement (julia-mode--latexsub-before-point))
       (progn

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -101,6 +101,7 @@ partial match for LaTeX completion, or `nil' when not applicable."
     (goto-char beg)
     (when (and (= (char-after) ?\\) (not (eobp)))
       (let ((beg (point)))
+        (forward-char)                  ; move past the \
         (cl-flet ((next-char-matches? ()
                                       (let* ((end (1+ (point)))
                                              (str (buffer-substring-no-properties beg end))

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -100,7 +100,6 @@ partial match for LaTeX completion, or `nil' when not applicable."
   (save-excursion
     (goto-char beg)
     (when (and (= (char-after) ?\\) (not (eobp)))
-      (forward-char)
       (let ((beg (point)))
         (cl-flet ((next-char-matches? ()
                                       (let* ((end (1+ (point)))

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -933,7 +933,7 @@ buffer where the LaTeX symbol starts."
 
 Presently, this is not the default. Enable with eg
 
-(define-key julia-mode-map (kbd \"TAB\") \'julia-latexsub-or-indent)
+(define-key julia-mode-map (kbd \"TAB\") 'julia-latexsub-or-indent)
 
  in your `julia-mode-hook'."
   (interactive "*i")


### PR DESCRIPTION
Fixes #193.

This is preliminary, **comments are welcome**, even along the lines of "Tamás your elisp code is so horrible that I had to wash my eyes with soap after reading it, here is how you do it nicer".

Try it with
```emacs-lisp
(define-key julia-mode-map (kbd "TAB") 'julia-latexsub-or-indent)
```
Maybe we can add an option for it.

Possible improvements:

- [ ] use something else than `completing-read`? is there a nicer popup version?
- [ ] annotate with the actual replacement in `completing-read`
- [x] option for greedy replacement for a full match (eg `\bar` will replace, no popup)
- [ ] option to pick the first replacement, whatever it is

Have to do before merging this:

- [x] some unit tests
- [ ] code review from someone
- [x] some testing by interested users