### PR TITLE
Fix const definition regex to match symbols with underscores etc.

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -758,6 +758,16 @@ var = func(begin
     (julia--should-font-lock string 11 nil) ; =
     ))
 
+(ert-deftest julia--test-const-def-font-lock-underscores ()
+  (let ((string "@macro const foo_bar = \"bar\""))
+    (julia--should-font-lock string 8 font-lock-keyword-face) ; const
+    (julia--should-font-lock string 12 font-lock-keyword-face) ; const
+    (julia--should-font-lock string 14 font-lock-variable-name-face) ; foo
+    (julia--should-font-lock string 17 font-lock-variable-name-face) ; _
+    (julia--should-font-lock string 20 font-lock-variable-name-face) ; bar
+    (julia--should-font-lock string 22 nil) ; =
+    ))
+
 ;;; Movement
 (ert-deftest julia--test-beginning-of-defun-assn-1 ()
   "Point moves to beginning of single-line assignment function."

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -290,10 +290,10 @@ partial match for LaTeX completion, or `nil' when not applicable."
 
 (defconst julia-const-def-regex
   (rx
-   bol (zero-or-more space)
-   "const" space
-   (group (one-or-more alnum)) (zero-or-more space)
-   "=" (not (any "="))))
+   symbol-start "const" (1+ space)
+   (group (minimal-match (seq symbol-start (one-or-more anychar) symbol-end)))
+   (zero-or-more space)
+   "="))
 
 (defconst julia-type-annotation-regex
   (rx "::" (0+ space) (group (1+ (or word (syntax symbol))))))


### PR DESCRIPTION
Regex introduced in #177 doesn't match e.g. `const my_symbol_with_underscores = 0` or `x = const y = 1`.