### PR TITLE
Strip whitespace in latexsub :exit-function

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -963,6 +963,8 @@ end" 'end-of-defun "n == 0" "return fact(x)[ \n]+end" 'end 2))
   (should (equal (julia--call-latexsub-exit-function
                   "\\kappa\\alpha(" 7 13 "\\alpha" t)
                  "\\kappaα("))
+  ;; Test that whitespace is stripped from `:exit-function' NAME for compatibility with helm
+  (should (equal (julia--call-latexsub-exit-function "x\\alpha " 2 8 "\\alpha " t)  "xα "))
   ;; test that LaTeX not expanded when `julia-automatic-latexsub' is nil
   (should (equal (julia--call-latexsub-exit-function "\\alpha" 1 7 "\\alpha" nil) "\\alpha"))
   (should (equal (julia--call-latexsub-exit-function "x\\alpha " 2 8 "\\alpha" nil)  "x\\alpha "))

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -910,8 +910,12 @@ buffer where the LaTeX symbol starts."
         ;; <https://github.com/abo-abo/swiper/issues/2345>). Instead of automatic
         ;; expansion, user can either enable `abbrev-mode' or call `expand-abbrev'.
         (when-let (((eq status 'finished))
-                   (symb (abbrev-symbol name julia-latexsub-abbrev-table))
-                   (end (+ beg (length name))))
+                   ;; helm-mode passes NAME with an extra whitespace at the end. Since
+                   ;; `julia--latexsub-start-symbol' won't include whitespace, we can safely
+                   ;; strip whitespace.
+                   (clean-name (string-clean-whitespace name))
+                   (symb (abbrev-symbol clean-name julia-latexsub-abbrev-table))
+                   (end (+ beg (length clean-name))))
           (abbrev-insert symb name beg end)))
     #'ignore))
 

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -913,7 +913,7 @@ buffer where the LaTeX symbol starts."
                    ;; helm-mode passes NAME with an extra whitespace at the end. Since
                    ;; `julia--latexsub-start-symbol' won't include whitespace, we can safely
                    ;; strip whitespace.
-                   (clean-name (string-clean-whitespace name))
+                   (clean-name (string-trim-right name))
                    (symb (abbrev-symbol clean-name julia-latexsub-abbrev-table))
                    (end (+ beg (length clean-name))))
           (abbrev-insert symb name beg end)))


### PR DESCRIPTION
According to the docstring for `completion-extra-properties`, the `string` passed to the `:exit-function` should be the bare text to which the field was completed, but helm-mode adds an extra space at the end of `string`. Since none of our latexsubs include whitespace, we can safely strip whitespace in the `:exit-function` and work around this helm bug.

I will file an upstring bug report against helm, but I think it's worth fixing quickly here since it's only a simple 3-line change.

Closes #204.

@tpapp, @giordano, or @FelipeLema could one of you review please? This fixes an extremely annoying bug for anyone using helm. @giordano, could you please double-check that this fixes the issue for you if you get a chance?