### PR TITLE
Remove unused cl lib

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -36,11 +36,6 @@
 
 ;;; Code:
 
-;; We can't use cl-lib whilst supporting Emacs 23 users who don't use
-;; ELPA.
-(with-no-warnings
-  (require 'cl)) ;; incf, decf, plusp
-
 (require 'julia-mode)
 (require 'ert)
 


### PR DESCRIPTION
By my reading of this source file there's no actual usage of the stuff in cl anymore so we don't even need to use cl-lib (I might be wrong here though)